### PR TITLE
LNZInfiniteCollectionViewLayout potential crash fix

### DIFF
--- a/LNZCollectionLayouts/Layouts/LNZInfiniteCollectionViewLayout.swift
+++ b/LNZCollectionLayouts/Layouts/LNZInfiniteCollectionViewLayout.swift
@@ -123,7 +123,7 @@ open class LNZInfiniteCollectionViewLayout: LNZSnapToCenterCollectionViewLayout 
     }
     
     override internal func items(in rect: CGRect) -> [(index:IndexPath, frame: CGRect)] {
-        guard let cycleSize = cycleSize,
+        guard let cycleSize = cycleSize, cycleSize.width != 0,
             let itemCount = itemCount, itemCount > 0 else { return [] }
         
         //We need to determine which are the cycles currently displayed on the screen. So that we can determine the array of elements 


### PR DESCRIPTION
Potential fix for the following crash: https://www.fabric.io/s5a/ios/apps/com.saksfifthavenue.iphone/issues/599e7c19be077a4dcc8870e7?time=last-seven-days

My guess is that this problem happens when for some reason itemCount is set to 0 when prepare() is called, so that cycleSize.width is set to 0. Or itemSize.width + interitemSpacing is 0.
`let width = (itemSize.width + interitemSpacing) * CGFloat(itemCount ?? 0)`
Later on when `override internal func items(in rect: CGRect) -> [(index:IndexPath, frame: CGRect)]` is called and itemCount is greater than 0, which is checked at the start of the method, cycleSize.width remains set to 0 and crash happens `let iFirstCycle = Int(floor((rect.origin.x - cycleStart) / cycleSize.width))`. 

My concern here is that this fix can potentially cause a bug where with a valid content (items count > 0) we'll get a zero width frames for items, so in the end content won't be visible. So i would consider to invalidate layout when needed. 
