### PR TITLE
Xcode 9.3 compilation error fix

### DIFF
--- a/LNZCollectionLayouts/Layouts/LNZSnapToCenterCollectionViewLayout.swift
+++ b/LNZCollectionLayouts/Layouts/LNZSnapToCenterCollectionViewLayout.swift
@@ -144,8 +144,8 @@ open class LNZSnapToCenterCollectionViewLayout: UICollectionViewLayout, FocusedC
             footerHeight = delegate?.collectionView?(collection, layout: self, referenceSizeForFooterInSection: 0).height ?? 0
         }
         //This method is always called right after the prepare method, so at this point sectionInsetLeft + sectionInsetRight is already determined
-        let w = sectionInsetLeft + sectionInsetRight - interitemSpacing + (itemSize.width + interitemSpacing) * CGFloat(itemCount ?? 0)
-        let h = (headerHeight ?? 0) + sectionInsetTop + sectionInsetBottom + itemSize.height + (footerHeight ?? 0)
+        let w: CGFloat = sectionInsetLeft + sectionInsetRight - interitemSpacing + (itemSize.width + interitemSpacing) * CGFloat(itemCount ?? 0)
+        let h: CGFloat = (headerHeight ?? 0.0) + sectionInsetTop + sectionInsetBottom + itemSize.height + (footerHeight ?? 0.0)
         
         return CGSize(width: w, height: h)
     }


### PR DESCRIPTION
Xcode 9.3 is showing an error `"Expression was too complex to be solved in a reasonable time"` for this expression. I just added `CGFloat` to help the compiler to understand a result type.