### PR TITLE
LNZInfiniteCollectionViewLayout: fix crash when rotating iPad

### DIFF
--- a/LNZCollectionLayouts/Layouts/LNZInfiniteCollectionViewLayout.swift
+++ b/LNZCollectionLayouts/Layouts/LNZInfiniteCollectionViewLayout.swift
@@ -144,7 +144,7 @@ open class LNZInfiniteCollectionViewLayout: LNZSnapToCenterCollectionViewLayout 
             let relativInitialX = currentX - cycleFrame.origin.x
             let relativeFinalX = min(cycleFrame.maxX, rect.maxX) - cycleFrame.origin.x
             
-            let firstIndex = Int(floor(relativInitialX/(itemSize.width + interitemSpacing)))
+            let firstIndex = min(Int(floor(relativInitialX/(itemSize.width + interitemSpacing))), itemCount-1)
             let lastIndex = min(Int(floor(relativeFinalX/(itemSize.width + interitemSpacing))), itemCount-1)
             
             for j in firstIndex...lastIndex {


### PR DESCRIPTION
Hi @gringoireDM, 

thanks for your work on this awesome library. 

This PR fixes a very frequent crash that occurs when rotating iPads from portrait to landscape mode while the infinite scrolling is going.

Please check the screenshot below, the problem occurs when `relativeInitialX` and `relativeFinalX` grow too big, while the lastIndex is capped by `min()` , firstIndex is not. So as in the example we got an invalid range (`5...3`), and thus the crash.

Please check this PR when you can, thank you.

`Can't form Range with upperBound < lowerBound`
<img width="1119" alt="Screenshot 2020-03-17 at 12 53 58" src="https://user-images.githubusercontent.com/2436636/76853861-60439100-684e-11ea-918e-0048ee5e6b88.png">
