### PR TITLE
Support Carthage by marking scheme as shared

### DIFF
--- a/LNZCollectionLayouts.xcodeproj/xcshareddata/xcschemes/LNZCollectionLayouts.xcscheme
+++ b/LNZCollectionLayouts.xcodeproj/xcshareddata/xcschemes/LNZCollectionLayouts.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1140"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "500D6EF91F1E1CFD00FE20D4"
+               BuildableName = "LNZCollectionLayouts.app"
+               BlueprintName = "LNZCollectionLayouts"
+               ReferencedContainer = "container:LNZCollectionLayouts.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "500D6EF91F1E1CFD00FE20D4"
+            BuildableName = "LNZCollectionLayouts.app"
+            BlueprintName = "LNZCollectionLayouts"
+            ReferencedContainer = "container:LNZCollectionLayouts.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "500D6EF91F1E1CFD00FE20D4"
+            BuildableName = "LNZCollectionLayouts.app"
+            BlueprintName = "LNZCollectionLayouts"
+            ReferencedContainer = "container:LNZCollectionLayouts.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
Currently only Cocoapods is supported for dependency management however it would be great in order to provide support for other dependency management systems including [Carthage](https://github.com/Carthage/Carthage).

Supporting Carthage is usually relatively straightforwards and should only require marking the project's scheme as shared which is what this PR does.

Thanks for creating this project 🙏 