### PR TITLE
Added listening changes alpha of side items.

### DIFF
--- a/LNZCollectionLayouts/Layouts/LNZCarouselCollectionViewLayout.swift
+++ b/LNZCollectionLayouts/Layouts/LNZCarouselCollectionViewLayout.swift
@@ -32,6 +32,9 @@ open class LNZCarouselCollectionViewLayout: LNZInfiniteCollectionViewLayout {
     ///to the distance of its center to the collection's center.
     @IBInspectable public var minimumScaleFactor: CGFloat = 0.85
     
+    ///The minimum value of alpha for items not in focus.
+    @IBInspectable public var sideItemAlpha: CGFloat = 1.0
+    
     //MARK: - Utility properties
     
     override var canInfiniteScroll: Bool { return super.canInfiniteScroll && isInfiniteScrollEnabled }
@@ -63,6 +66,10 @@ open class LNZCarouselCollectionViewLayout: LNZInfiniteCollectionViewLayout {
         //property.
         attributes.zIndex = Int(scale * 100000)
         attributes.transform3D = CATransform3DScale(CATransform3DIdentity, scale, scale, 1)
+        
+        if sideItemAlpha != 1.0 {
+            shouldChangeAlpha(collection, attributes: attributes)
+        }
     }
     
     open override func layoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
@@ -83,5 +90,19 @@ open class LNZCarouselCollectionViewLayout: LNZInfiniteCollectionViewLayout {
         guard let attribute = super.layoutAttributesForItem(at: indexPath) else { return nil }
         configureAttributes(for: attribute)
         return attribute
+    }
+    
+    private func shouldChangeAlpha(_ collectionView: UICollectionView, attributes: UICollectionViewLayoutAttributes) {
+        let collectionCenter = collectionView.frame.size.width / 2
+        let offset = collectionView.contentOffset.x
+        let normalizedCenter = attributes.center.x - offset
+        
+        let maxDistance = self.itemSize.width
+        let distance = min(abs(collectionCenter - normalizedCenter), maxDistance)
+        let ratio = (maxDistance - distance) / maxDistance
+        
+        let alpha = ratio * (1 - self.sideItemAlpha) + self.sideItemAlpha
+        
+        focusChangeDelegate?.didChangeAlpha(alpha, for: attributes.indexPath)
     }
 }

--- a/LNZCollectionLayouts/Layouts/LNZSnapToCenterCollectionViewLayout.swift
+++ b/LNZCollectionLayouts/Layouts/LNZSnapToCenterCollectionViewLayout.swift
@@ -10,7 +10,7 @@ import UIKit
 
 ///This methods will be called on the delegate whenever a centered element is changing. In fact as element in focus is to be intended
 ///as element currently centered
-@objc public protocol FocusChangeDelegate: class {
+@objc public protocol FocusChangeDelegate: AnyObject {
     ///This method will signal to the delegate that the element in focus will change.
     ///- parameter container: The object that is tracking the focused element
     ///- parameter inFocus: The element currently in focus (before the change)
@@ -21,10 +21,15 @@ import UIKit
     ///- parameter container: The object that is tracking the focused element
     ///- parameter inFocus: The element currently in focus
     func focusContainer(_ container: FocusedContaining, didChangeElement inFocus: Int)
+    
+    ///This method will signal to the delegate that the elements can change alpha.
+    ///- parameter alpha: The value of alpha
+    ///- parameter indexPath: The indexPath of element
+    func didChangeAlpha(_ alpha: CGFloat, for indexPath: IndexPath)
 }
 
 ///An object conforming FocusContaining will track elements in focus in a collection and will alert the delegate for changes-
-@objc public protocol FocusedContaining: class {
+@objc public protocol FocusedContaining: AnyObject {
     ///The element currently in focus
     var currentInFocus: Int { get }
     


### PR DESCRIPTION
This allow to change alpha value for side items. If `sideItemAlpha = 0`, then left and right not centered items has alpha = 0. It allows to change alpha for some elements in the cell. 

Example.
`  func didChangeAlpha(_ alpha: CGFloat, for indexPath: IndexPath) {
        guard let cell = collectionView.cellForItem(at: indexPath) as? MagazineCell else { return }
        cell.setTextContentAlpha(alpha)
    }
}`

`func setTextContentAlpha(_ alpha: CGFloat) {
        titleLabel.alpha = alpha
        descriptionLabel.alpha = alpha
        timingView.alpha = alpha
        freeView.alpha = alpha
        freeLabel.alpha = alpha
        iconImageView.alpha = alpha
        iconBackgroundImageView.alpha = alpha
    }`